### PR TITLE
use particle spawner instead of individual particles

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -92,7 +92,7 @@ local create_confetti = function(itemstack, user, _pointed_thing, texpool)
             style = "pulse",
             reps = 3,
             { min = vector.new(0, 0, 0),             max = vector.new(0, 0, 0), },
-            { min = vector.new(-jitter, 0, -jitter), max = vector.new(jitter, 0, jitter), }
+            { min = vector.new(-jitter, -jitter*0.2, -jitter), max = vector.new(jitter, jitter*0.4, jitter), }
         },
         attract = {
             kind = "point",

--- a/init.lua
+++ b/init.lua
@@ -21,12 +21,26 @@ DEALINGS IN THE SOFTWARE.
 
 ]]
 
+local modname = minetest.get_current_modname()
+
+minetest.log("action", "[MOD] " .. modname .. " loading...")
+
+local modpath = minetest.get_modpath(modname)
+
+confetti = {}
+confetti.particle_amount = tonumber(minetest.settings:get(modname .. ".particle_amount")) or 110
+confetti.cooldown = tonumber(minetest.settings:get(modname .. ".cooldown_delay")) or 0.3
+
+-- needed for the cooldown, stores last time player used confetti
+local player_last_use = {}
+
+
 minetest.register_craft({
     output = "confetti:confetti_rainbow",
     recipe = {
-        {"", "dye:blue", "dye:yellow"},
-        {"", "default:stick", "dye:red"},
-        {"default:stick", "", ""},
+        { "",              "dye:blue",      "dye:yellow" },
+        { "",              "default:stick", "dye:red" },
+        { "default:stick", "",              "" },
     }
 })
 
@@ -34,48 +48,119 @@ local confetti_colors = {
     "red", "blue", "green", "white", "yellow", "black", "violet", "pink", "orange", "cyan", "brown"
 }
 
+local rainbow_texpool = {}
+for _, color in ipairs(confetti_colors) do
+    if color ~= "black" then -- don't like that one
+        table.insert(rainbow_texpool, "confetti_" .. color .. ".png")
+    end
+end
+
+-- get actual eye_pos of the player (including eye_offset)
+local function player_get_rel_eye_pos(player)
+    local p_pos = vector.zero()
+    local p_eye_height = player:get_properties().eye_height
+    p_pos.y = p_pos.y + p_eye_height
+    local p_eye_pos = p_pos
+    local p_eye_offset = vector.multiply(player:get_eye_offset(), 0.1)
+    local yaw = player:get_look_horizontal()
+    p_eye_pos = vector.add(p_eye_pos, vector.rotate_around_axis(p_eye_offset, { x = 0, y = 1, z = 0 }, yaw))
+    return p_eye_pos
+end
+
+local create_confetti = function(itemstack, user, _pointed_thing, texpool)
+    if not user or not user:is_player() then
+        return
+    end
+    local rel_eye_pos = player_get_rel_eye_pos(user)
+    local pos = vector.add(user:get_pos(), rel_eye_pos)
+
+    local dir = user:get_look_dir()
+    local particle_amount = confetti.particle_amount
+    local particle_size = 1.0
+    local jitter = 10
+
+    local origin = vector.add(vector.multiply(dir, 0.5), vector.subtract(rel_eye_pos, vector.new(0, 1, 0)))
+    local sound_pos = vector.add(origin, pos)
+
+    local def = {
+        amount = particle_amount,
+        time = 0.01,
+        pos = vector.add(pos, vector.multiply(dir, 1.0)),
+        radius = { min = 0.0, max = 0.3, bias = -10 },
+        drag_tween = { vector.new(1.5, 0, 1.5), 0.1 },
+        jitter_tween = {
+            style = "pulse",
+            reps = 3,
+            { min = vector.new(0, 0, 0),             max = vector.new(0, 0, 0), },
+            { min = vector.new(-jitter, 0, -jitter), max = vector.new(jitter, 0, jitter), }
+        },
+        attract = {
+            kind = "point",
+            strength = -5.5,
+            origin = origin,
+        },
+        acc = { x = 0, y = -4, z = 0 },
+        exptime = 5,
+        size = particle_size,
+        collisiondetection = true,
+        collision_removal = true,
+        texpool = texpool,
+    }
+
+    if type(user) == "userdata" then
+        -- can attach only to entities/players
+        def.attract.origin_attached = user
+        def.attract.direction_attached = user
+    else
+        -- this is probably a nodebreaker?
+        def.attract.origin = vector.add(vector.multiply(dir, 0.5), pos)
+        sound_pos = vector.add(vector.multiply(dir, 0.5), pos)
+    end
+
+    minetest.add_particlespawner(def)
+
+    -- sound_name = "mesecons_button_pop"
+    -- minetest.sound_play(sound_name, {
+    --     pos = sound_pos,
+    --     max_hear_distance = 40,
+    --     gain = 1.0,
+    --     pitch = 6.0,
+    -- })
+
+    itemstack:take_item(1)
+    return itemstack
+end
+
 for _, color in ipairs(confetti_colors) do
     minetest.register_craft({
         output = "confetti:" .. color,
         recipe = {
-            {"", "dye:" .. color, "dye:" .. color},
-            {"", "default:stick", "dye:" .. color},
-            {"default:stick", "", ""},
+            { "",              "dye:" .. color, "dye:" .. color },
+            { "",              "default:stick", "dye:" .. color },
+            { "default:stick", "",              "" },
         }
     })
+
+    local texpool = { "confetti_" .. color .. ".png" }
 
     minetest.register_craftitem("confetti:" .. color, {
         description = color:gsub("^%l", string.upper) .. " Confetti",
         inventory_image = "confetti_" .. color .. "_item.png",
         stack_max = 99,
         on_use = function(itemstack, user, pointed_thing)
-            local pos = user:getpos()
-            local dir = user:get_look_dir()
-            local velocity = 8
-            local particle_amount = 110
-            local particle_size = 1.5
+            if user and type(user) == "userdata" and user:is_player() then
+                local player_name = user:get_player_name()
 
-            for _ = 1, particle_amount do
-                local random_vel = {
-                    x = dir.x * velocity + math.random(-5, 5),
-                    y = dir.y * velocity + math.random(-5, 5),
-                    z = dir.z * velocity + math.random(-5, 5)
-                }
-
-                minetest.add_particle({
-                    pos = {x = pos.x, y = pos.y + 1.5, z = pos.z},
-                    velocity = random_vel,
-                    acceleration = {x = 0, y = -10, z = 0},
-                    expirationtime = 8,
-                    size = particle_size,
-                    collisiondetection = true,
-                    collision_removal = true,
-                    texture = "confetti_" .. color .. ".png",
-                })
+                local current_time = minetest.get_us_time()/1000000
+                local last_time = player_last_use[player_name]
+                if last_time and current_time - last_time < confetti.cooldown then
+                    --minetest.chat_send_player(player_name, ("Don't spam, wait %fs."):format(confetti.cooldown - (current_time - last_time)))
+                    return
+                end
+                player_last_use[player_name] = current_time
             end
 
-            itemstack:take_item(1)
-            return itemstack
+            create_confetti(itemstack, user, pointed_thing, texpool)
         end,
     })
 end
@@ -85,36 +170,27 @@ minetest.register_craftitem("confetti:confetti_rainbow", {
     inventory_image = "confetti_rainbow.png",
     stack_max = 99,
     on_use = function(itemstack, user, pointed_thing)
-        local pos = user:getpos()
-        local dir = user:get_look_dir()
-        local velocity = 8
-        local particle_amount = 10
-        local particle_size = 1.5
+        -- FIXME check if user is a player
+        if user and type(user) == "userdata" and user:is_player() then
+            local player_name = user:get_player_name()
 
-        for _, color in ipairs(confetti_colors) do
-            for _ = 1, particle_amount do
-                local random_vel = {
-                    x = dir.x * velocity + math.random(-5, 5),
-                    y = dir.y * velocity + math.random(-5, 5),
-                    z = dir.z * velocity + math.random(-5, 5)
-                }
-
-                minetest.add_particle({
-                    pos = {x = pos.x, y = pos.y + 1.5, z = pos.z},
-                    velocity = random_vel,
-                    acceleration = {x = 0, y = -10, z = 0},
-                    expirationtime = 8,
-                    size = particle_size,
-                    collisiondetection = true,
-                    collision_removal = true,
-                    texture = "confetti_" .. color .. ".png",
-                })
+            local current_time = minetest.get_us_time()/1000000
+            local last_time = player_last_use[player_name]
+            if last_time and current_time - last_time < confetti.cooldown then
+                --minetest.chat_send_player(player_name, ("Don't spam, wait %fs."):format(confetti.cooldown - (current_time - last_time)))
+                return
             end
+            player_last_use[player_name] = current_time
         end
 
-        itemstack:take_item(1)
-        return itemstack
+        create_confetti(itemstack, user, pointed_thing, rainbow_texpool)
     end,
 })
 
-print('[Confetti] loaded...')
+minetest.register_on_leaveplayer(
+    function(player_obj, _)
+        player_last_use[player_obj:get_player_name()] = nil
+    end
+)
+
+minetest.log("action", "[MOD] " .. modname .. " loaded.")

--- a/init.lua
+++ b/init.lua
@@ -160,7 +160,7 @@ for _, color in ipairs(confetti_colors) do
                 player_last_use[player_name] = current_time
             end
 
-            create_confetti(itemstack, user, pointed_thing, texpool)
+            return create_confetti(itemstack, user, pointed_thing, texpool)
         end,
     })
 end
@@ -183,7 +183,7 @@ minetest.register_craftitem("confetti:confetti_rainbow", {
             player_last_use[player_name] = current_time
         end
 
-        create_confetti(itemstack, user, pointed_thing, rainbow_texpool)
+        return create_confetti(itemstack, user, pointed_thing, rainbow_texpool)
     end,
 })
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+confetti.cooldown_delay (Cooldown in seconds after confetti use [per player]) float 0.3 0 600
+confetti.particle_amount (Number of particles per one confetti use) int 110 1 100000


### PR DESCRIPTION
Spawning 100 individual particles creates excessive network traffic, which in turn makes some clients lag for minutes after lots of confetti was spammed. This may be engine bug or our settings, but it's better to just use spawners anyway.

Also added 2 configurable parameters: usage cooldown and number of particles.